### PR TITLE
docker-compose.ymlのネットワーク定義を明示的にする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - "5173"
     ports:
       - "5173:5173"
+    networks:
+      - app-network
     command: npm run dev
 
   # FastAPIバックエンドサービス
@@ -40,6 +42,8 @@ services:
       - "8000"
     ports:
       - "8000:8000"
+    networks:
+      - app-network
     depends_on:
       - db
 
@@ -62,6 +66,8 @@ services:
     # MySQLのポートを外部に公開する場合
     ports:
       - "3306:3306"
+    networks:
+      - app-network
     volumes:
       # データベースのデータを永続化
       - db_data:/var/lib/mysql
@@ -71,3 +77,7 @@ services:
 # 永続化のためのボリュームを定義
 volumes:
   db_data:
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
バックエンドとデータベース間の接続できない事象の対策